### PR TITLE
Group functions

### DIFF
--- a/src/client/app/components/InitializationComponent.tsx
+++ b/src/client/app/components/InitializationComponent.tsx
@@ -27,6 +27,7 @@ export default function InitializationComponent() {
 	// Only run once by making it depend on an empty array.
 	useEffect(() => {
 		dispatch(fetchMetersDetailsIfNeeded());
+		// TODO: Should only fetch groups when the user is an admin and they view the group page.
 		dispatch(fetchGroupsDetailsIfNeeded());
 		dispatch(fetchPreferencesIfNeeded());
 		dispatch(fetchMapsDetails());

--- a/src/client/app/components/unit/CreateUnitModalComponent.tsx
+++ b/src/client/app/components/unit/CreateUnitModalComponent.tsx
@@ -14,6 +14,7 @@ import TooltipMarkerComponent from '../TooltipMarkerComponent';
 import TooltipHelpContainer from '../../containers/TooltipHelpContainer';
 import { UnitRepresentType, DisplayableType, UnitType } from '../../types/redux/units';
 import { addUnit } from '../../actions/units';
+import { getMeterMenuOptionsForGroup } from '../../utils/determineCompatibleUnits';
 
 export default function CreateUnitModalComponent() {
 	const dispatch = useDispatch();
@@ -94,6 +95,9 @@ export default function CreateUnitModalComponent() {
 	const tableStyle: React.CSSProperties = {
 		width: '100%'
 	};
+
+	const tmp = getMeterMenuOptionsForGroup(2);
+	console.log(tmp);
 
 	return (
 		<>

--- a/src/client/app/components/unit/CreateUnitModalComponent.tsx
+++ b/src/client/app/components/unit/CreateUnitModalComponent.tsx
@@ -14,7 +14,6 @@ import TooltipMarkerComponent from '../TooltipMarkerComponent';
 import TooltipHelpContainer from '../../containers/TooltipHelpContainer';
 import { UnitRepresentType, DisplayableType, UnitType } from '../../types/redux/units';
 import { addUnit } from '../../actions/units';
-import { getMeterMenuOptionsForGroup } from '../../utils/determineCompatibleUnits';
 
 export default function CreateUnitModalComponent() {
 	const dispatch = useDispatch();
@@ -95,9 +94,6 @@ export default function CreateUnitModalComponent() {
 	const tableStyle: React.CSSProperties = {
 		width: '100%'
 	};
-
-	const tmp = getMeterMenuOptionsForGroup(2);
-	console.log(tmp);
 
 	return (
 		<>

--- a/src/client/app/reducers/groups.ts
+++ b/src/client/app/reducers/groups.ts
@@ -38,9 +38,7 @@ export default function groups(state = defaultState, action: GroupsAction) {
 			const newGroups = action.data.map(group => ({
 				...group,
 				isFetching: false,
-				outdated: true,
-				childGroups: [],
-				childMeters: [],
+				outdated: false,
 				selectedGroups: [],
 				selectedMeters: []
 			}));

--- a/src/client/app/types/items.ts
+++ b/src/client/app/types/items.ts
@@ -13,6 +13,7 @@ export interface SelectOption {
 	value: number;
 	isDisabled?: boolean;
 	labelIdForTranslate?: string;
+	style?: React.CSSProperties;
 }
 
 /**

--- a/src/client/app/utils/api/GroupsApi.ts
+++ b/src/client/app/utils/api/GroupsApi.ts
@@ -38,6 +38,10 @@ export default class GroupsApi {
 		return await this.backend.doPostRequest('api/groups/delete', { id: groupID });
 	}
 
+	public async getParentIDs(groupID: number): Promise<number[]> {
+		return await this.backend.doGetRequest<number[]>(`api/groups/parents/${groupID}`);
+	}
+
 	/**
 	 * Gets compare readings for groups for the given current time range and a shift for previous time range
 	 * @param groupIDs The group IDs to get readings for

--- a/src/client/app/utils/determineCompatibleUnits.ts
+++ b/src/client/app/utils/determineCompatibleUnits.ts
@@ -166,7 +166,7 @@ export function getMeterMenuOptionsForGroup(gid: number): SelectOption[] {
 			label: meter.identifier,
 			value: meter.id,
 			isDisabled: false,
-			style: {},
+			style: {}
 		} as SelectOption;
 
 		const compatibilityChangeCase = getCompatibilityChangeCase(currentUnits, meter.id, DataType.Meter, defaultGraphicUnit);
@@ -203,7 +203,7 @@ export function getGroupMenuOptionsForGroup(gid: number): SelectOption[] {
 			label: group.name,
 			value: group.id,
 			isDisabled: false,
-			style: {},
+			style: {}
 		} as SelectOption;
 
 		const compatibilityChangeCase = getCompatibilityChangeCase(currentUnits, group.id, DataType.Group, defaultGraphicUnit);
@@ -275,7 +275,6 @@ export async function assignChildToGroup(gid: number, childId: number, childType
  * Warns admin of changes and returns true if the changes should happen.
  * @param gid The group that has a change in compatible units.
  * @param parentGroupIDs The parent groups' ids of that group.
- * @returns 
  */
 async function validateGroupPostAddChild(gid: number, parentGroupIDs: number[]): Promise<boolean> {
 	const state = store.getState() as State;
@@ -345,7 +344,7 @@ async function applyChangesToGroup(group: GroupDefinition): Promise<void> {
 
 /**
  * The four cases that could happen when adding a group/meter to a group:
- * 	- NoChange: Adding this meter/group will not change the compatible units for the group. 
+ * 	- NoChange: Adding this meter/group will not change the compatible units for the group.
  *  - LostCompatibleUnits: The meter/group is compatible with the default graphic unit although some compatible units are lost.
  *  - LostDefaultGraphicUnits: The meter/group is not compatible with the default graphic unit but there exists some compatible untis.
  *  - NoCompatibleUnits: The meter/group will cause the compatible units for the group to be empty.
@@ -359,16 +358,16 @@ export const enum GroupCase {
 
 /**
  * Return the case associated if we add the given meter/group to a group.
- * @param currentCompatibleUnits The current compatible units of the group.
+ * @param currentUnits The current compatible units of the group.
  * @param idToAdd The meter/group's id to add to the group.
  * @param type Can be METER or GROUP.
  * @param currentDefaultGraphicUnit The default graphic unit.
  */
-function getCompatibilityChangeCase(currentCompatibleUnits: Set<number>, idToAdd: number, type: DataType, currentDefaultGraphicUnit: number): GroupCase {
+function getCompatibilityChangeCase(currentUnits: Set<number>, idToAdd: number, type: DataType, currentDefaultGraphicUnit: number): GroupCase {
 	// Determine the compatible units for meter or group represented by the id.
 	const newUnits = getCompatibleUnits(idToAdd, type);
 	// Returns the associated case.
-	return groupCase(currentCompatibleUnits, newUnits, currentDefaultGraphicUnit);
+	return groupCase(currentUnits, newUnits, currentDefaultGraphicUnit);
 }
 
 /**
@@ -399,8 +398,8 @@ function groupCase(currentUnits: Set<number>, newUnits: Set<number>, defaultGrap
 	// The compatible units of a set of meters or groups is the intersection of the compatible units for each
 	// Thus, we can get the units that will go away with (- is set subtraction/difference):
 	// lostUnit = currentUnit - ( currentUnit n newUnits)
-	let intersection = setIntersect(currentUnits, newUnits);
-	let lostUnits = new Set(Array.from(currentUnits).filter(x => !intersection.has(x)));
+	const intersection = setIntersect(currentUnits, newUnits);
+	const lostUnits = new Set(Array.from(currentUnits).filter(x => !intersection.has(x)));
 
 	if (lostUnits.size == 0) {
 		return GroupCase.NoChange;

--- a/src/server/models/Group.js
+++ b/src/server/models/Group.js
@@ -239,6 +239,17 @@ class Group {
 	}
 
 	/**
+	 * Returns a promise to retrieve an array of the group IDs of the parent groups of a group.
+	 * @param groupID the group's id that we need to find its parents.
+	 * @param conn the connection to be used.
+	 * @return {Promise<IArrayExt<any>>}
+	 */
+	static async getParentsByGroupID(groupID, conn) {
+		const rows = await conn.any(sqlFile('group/get_parents_by_group_id.sql'), { child_id: groupID });
+		return rows.map(row => row.parent_id);
+	}
+
+	/**
 	 * Returns a promise to delete a group and purge all trace of it form the memories of its parents and children
 	 * @param groupID The ID of the group to be deleted
 	 * @param conn the connection to be used.

--- a/src/server/routes/groups.js
+++ b/src/server/routes/groups.js
@@ -150,10 +150,36 @@ router.get('/deep/meters/:group_id', async (req, res) => {
 	}
 });
 
+router.get('/parents/:group_id', async (req, res) => {
+	const validParams = {
+		type: 'object',
+		maxProperties: 1,
+		required: ['group_id'],
+		properties: {
+			group_id: {
+				type: 'string',
+				pattern: '^\\d+$'
+			}
+		}
+	};
+	if (!validate(req.params, validParams).valid) {
+		res.sendStatus(400);
+	} else {
+		const conn = getConnection();
+		try {
+			const parentGroups = await Group.getParentsByGroupID(req.params.group_id, conn);
+			res.json(parentGroups);
+		} catch (err) {
+			log.error(`Error while preforming GET on all parents of specific group: ${err}`, err);
+			res.sendStatus(500);
+		}
+	}
+});
+
 router.post('/create', adminAuthenticator('create groups'), async (req, res) => {
 	const validGroup = {
 		type: 'object',
-		maxProperties: 7,
+		maxProperties: 8,
 		required: ['name', 'childGroups', 'childMeters'],
 		properties: {
 			name: {
@@ -201,7 +227,8 @@ router.post('/create', adminAuthenticator('create groups'), async (req, res) => 
 				items: {
 					type: 'integer'
 				}
-			}
+			},
+			defaultGraphicUnit: { type: 'integer' }
 		}
 	};
 
@@ -219,7 +246,8 @@ router.post('/create', adminAuthenticator('create groups'), async (req, res) => 
 					req.body.displayable,
 					newGPS,
 					req.body.note,
-					req.body.area
+					req.body.area,
+					req.body.defaultGraphicUnit
 				);
 
 				await newGroup.insert(t);
@@ -242,7 +270,7 @@ router.post('/create', adminAuthenticator('create groups'), async (req, res) => 
 router.put('/edit', adminAuthenticator('edit groups'), async (req, res) => {
 	const validGroup = {
 		type: 'object',
-		maxProperties: 8,
+		maxProperties: 9,
 		required: ['id', 'name', 'childGroups', 'childMeters'],
 		properties: {
 			id: { type: 'integer' },
@@ -291,7 +319,8 @@ router.put('/edit', adminAuthenticator('edit groups'), async (req, res) => {
 				items: {
 					type: 'integer'
 				}
-			}
+			},
+			defaultGraphicUnit: { type: 'integer' }
 		}
 	};
 
@@ -313,7 +342,8 @@ router.put('/edit', adminAuthenticator('edit groups'), async (req, res) => {
 					req.body.displayable,
 					newGPS,
 					req.body.note,
-					req.body.area
+					req.body.area,
+					req.body.defaultGraphicUnit
 				);
 
 				await newGroup.update(t);


### PR DESCRIPTION
# Description

Implements the necessary functions for the group pages. Some main functions are:
- `getMeterMenuOptionsForGroup`: returns the options for the meter menu.
- `getGroupMenuOptionsForGroup`: returns the options for the group menu.
- `assignChildToGroup`: call this function after adding a meter/group to a specific group. It runs the check, displays warnings, and updates the database if necessary.

Some other changes:
- Group children are now fetched when OED starts running. Before that, it was fetched when a group is selected.
- Adds a new route to get a group's parents

## Type of change

- [ ] Note merging this changes the node modules
- [ ] Note merging this changes the database configuration.
- [ ] This change requires a documentation update

## Checklist

- [x] I have followed the [OED pull request](https://openenergydashboard.github.io/developer/pr.html) ideas
- [x] I have removed text in ( ) from the issue request

## Limitations

(Describe any issues that remain or work that should still be done.)
